### PR TITLE
Add multi-agent OpenAI demo with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # llm-call
+
+Prototype demonstrating a minimal multi-agent system using the OpenAI API. Two or more agents cooperate by exchanging messages through the API.
+
+## Requirements
+
+Install dependencies (including `openai`) via `pip`:
+
+```bash
+pip install -r requirements.txt
+```
+
+Set your `OPENAI_API_KEY` environment variable before running the example.
+
+## Running the main script
+
+Execute the main module to see a short chat between two agents:
+
+```bash
+python -m llm_call.main
+```
+
+If the `openai` package is not installed, or the API key is missing, the script will instruct you accordingly.
+
+## Running tests
+
+Run the test suite with:
+
+```bash
+pytest
+```

--- a/llm_call/__init__.py
+++ b/llm_call/__init__.py
@@ -1,0 +1,5 @@
+"""Minimal multi-agent demo package."""
+
+from .agents import Agent, MultiAgentSystem
+
+__all__ = ["Agent", "MultiAgentSystem"]

--- a/llm_call/agents.py
+++ b/llm_call/agents.py
@@ -1,0 +1,38 @@
+try:
+    import openai  # type: ignore
+except ImportError:  # pragma: no cover - handled via mock in tests
+    class _Dummy:
+        class ChatCompletion:
+            @staticmethod
+            def create(*args, **kwargs):  # pragma: no cover - replaced in tests
+                raise RuntimeError("openai package is required")
+
+    openai = _Dummy()
+
+
+class Agent:
+    """Simple wrapper around an OpenAI chat model."""
+
+    def __init__(self, name: str, model: str = "gpt-3.5-turbo") -> None:
+        self.name = name
+        self.model = model
+
+    def chat(self, messages):
+        """Send messages to the OpenAI API and return the assistant's reply."""
+        response = openai.ChatCompletion.create(model=self.model, messages=messages)
+        return response.choices[0].message["content"]
+
+
+class MultiAgentSystem:
+    """Coordinate a list of agents in a simple round-robin fashion."""
+
+    def __init__(self, agents):
+        self.agents = agents
+
+    def run(self, prompt: str, turns: int = 1):
+        messages = [{"role": "user", "content": prompt}]
+        for _ in range(turns):
+            for agent in self.agents:
+                reply = agent.chat(messages)
+                messages.append({"role": "assistant", "content": reply})
+        return messages

--- a/llm_call/main.py
+++ b/llm_call/main.py
@@ -1,0 +1,18 @@
+from .agents import Agent, MultiAgentSystem
+
+
+def main():
+    """Run a very small multi-agent demo."""
+    agents = [Agent("Alice"), Agent("Bob")]
+    system = MultiAgentSystem(agents)
+    try:
+        messages = system.run("Hello", turns=1)
+        for msg in messages:
+            print(f"{msg['role']}: {msg['content']}")
+    except RuntimeError as exc:
+        print(exc)
+        print("Please install the openai package and configure API credentials.")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai
+pytest

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,22 @@
+from unittest.mock import patch
+
+from llm_call.agents import Agent, MultiAgentSystem
+
+
+class DummyResponse:
+    def __init__(self, content):
+        self.choices = [type("obj", (), {"message": {"content": content}})]
+
+
+def fake_create(model, messages):
+    return DummyResponse(f"echo:{messages[-1]['content']}")
+
+
+def test_system_run():
+    agent = Agent(name="tester")
+    system = MultiAgentSystem([agent])
+
+    with patch("llm_call.agents.openai.ChatCompletion.create", side_effect=fake_create):
+        messages = system.run("hello", turns=1)
+
+    assert messages[-1]["content"] == "echo:hello"


### PR DESCRIPTION
## Summary
- replace previous example with a multi-agent system demo
- implement `Agent` and `MultiAgentSystem` classes
- run agents in `main.py`
- mock OpenAI API in `tests/test_agents.py`
- document usage and requirements in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cfed6f1508327a31cd8a86ef83c93