### PR TITLE
Implement agent registry distribution

### DIFF
--- a/llm_call/agents.py
+++ b/llm_call/agents.py
@@ -9,14 +9,28 @@ except ImportError:  # pragma: no cover - handled via mock in tests
 
     openai = _Dummy()
 
-import requests
+try:
+    import requests  # type: ignore
+except ImportError:  # pragma: no cover - handled via mock in tests
+    class _RequestsDummy:
+        @staticmethod
+        def post(*args, **kwargs):
+            raise RuntimeError("requests package is required")
+
+    requests = _RequestsDummy()
 
 class Agent:
-    """Simple wrapper around an OpenAI chat model."""
+    """Simple wrapper around an OpenAI chat model with a responsibility."""
 
-    def __init__(self, name: str, model: str = "gemma-3n-e4b-it-mlx") -> None:
+    def __init__(self, name: str, responsibility: str, model: str = "gemma-3n-e4b-it-mlx") -> None:
         self.name = name
         self.model = model
+        self.responsibility = responsibility
+        self.registry: dict[str, str] | None = None
+
+    def update_registry(self, registry: dict[str, str]) -> None:
+        """Store the system registry excluding this agent."""
+        self.registry = registry
 
     def chat(self, messages):
         """Envoie les messages à l'API locale et retourne la réponse de l'assistant."""
@@ -40,7 +54,16 @@ class MultiAgentSystem:
     def __init__(self, agents):
         self.agents = agents
 
+    def start(self) -> None:
+        """Distribute the registry of all agents to each participant."""
+        registry = {agent.name: agent.responsibility for agent in self.agents}
+        for agent in self.agents:
+            # each agent should not receive itself in the registry
+            other = {name: resp for name, resp in registry.items() if name != agent.name}
+            agent.update_registry(other)
+
     def run(self, prompt: str, turns: int = 1):
+        self.start()
         messages = [{"role": "user", "content": prompt}]
         for _ in range(turns):
             for agent in self.agents:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -19,10 +19,22 @@ def fake_post(url, json, headers):
 
 
 def test_system_run():
-    agent = Agent(name="tester")
+    agent = Agent(name="tester", responsibility="echo")
     system = MultiAgentSystem([agent])
 
     with patch("llm_call.agents.requests.post", side_effect=fake_post):
         messages = system.run("hello", turns=1)
     assert messages[-1]["content"] == "echo:hello"
     assert messages[-1]["name"] == "tester"
+
+
+def test_registry_distribution():
+    agent1 = Agent(name="agent1", responsibility="resp1")
+    agent2 = Agent(name="agent2", responsibility="resp2")
+    system = MultiAgentSystem([agent1, agent2])
+
+    with patch("llm_call.agents.requests.post", side_effect=fake_post):
+        system.run("hi", turns=0)
+
+    assert agent1.registry == {"agent2": "resp2"}
+    assert agent2.registry == {"agent1": "resp1"}


### PR DESCRIPTION
## Summary
- support dummy `requests` fallback
- add responsibility tracking for each agent
- broadcast agent registry on system startup
- test registry distribution and update agent constructor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0d194c6c83278eb6d16d625e9048