### PR TITLE
Add targeted agent messaging and command agent

### DIFF
--- a/llm_call/__init__.py
+++ b/llm_call/__init__.py
@@ -1,5 +1,5 @@
 """Minimal multi-agent demo package."""
 
-from .agents import Agent, MultiAgentSystem
+from .agents import Agent, CommandAgent, MultiAgentSystem
 
-__all__ = ["Agent", "MultiAgentSystem"]
+__all__ = ["Agent", "CommandAgent", "MultiAgentSystem"]

--- a/llm_call/agents.py
+++ b/llm_call/agents.py
@@ -33,7 +33,7 @@ class Agent:
         self.registry = registry
 
     def chat(self, messages):
-        """Envoie les messages à l'API locale et retourne la réponse de l'assistant."""
+        """Send a raw list of messages to the chat API and return the reply."""
         url = "http://localhost:1234/v1/chat/completions"
         payload = {
             "model": self.model,
@@ -47,20 +47,61 @@ class Agent:
         response.raise_for_status()
         return response.json()["choices"][0]["message"]["content"]
 
+    def reply(self, message: str) -> str:
+        """Reply to a single user message."""
+        return self.chat([{"role": "user", "content": message}])
+
+
+class CommandAgent(Agent):
+    """Agent executing shell commands instead of using an LLM."""
+
+    def __init__(self, name: str, responsibility: str, root: str) -> None:
+        super().__init__(name, responsibility)
+        self.root = root
+
+    def reply(self, message: str) -> str:  # type: ignore[override]
+        import subprocess
+
+        result = subprocess.run(
+            message,
+            shell=True,
+            capture_output=True,
+            text=True,
+            cwd=self.root,
+        )
+        output = result.stdout + result.stderr
+        return output.strip()
+
 
 class MultiAgentSystem:
     """Coordinate a list of agents in a simple round-robin fashion."""
 
     def __init__(self, agents):
         self.agents = agents
+        self.started = False
 
     def start(self) -> None:
         """Distribute the registry of all agents to each participant."""
+        if self.started:
+            return
         registry = {agent.name: agent.responsibility for agent in self.agents}
         for agent in self.agents:
             # each agent should not receive itself in the registry
             other = {name: resp for name, resp in registry.items() if name != agent.name}
             agent.update_registry(other)
+        self.started = True
+
+    def _get_agent(self, name: str) -> Agent:
+        for agent in self.agents:
+            if agent.name == name:
+                return agent
+        raise ValueError(f"Unknown agent: {name}")
+
+    def send_message(self, agent_name: str, body: str) -> str:
+        """Send ``body`` to the specified agent and return its reply."""
+        self.start()
+        agent = self._get_agent(agent_name)
+        return agent.reply(body)
 
     def run(self, prompt: str, turns: int = 1):
         self.start()

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from llm_call.agents import Agent, MultiAgentSystem
+from llm_call.agents import Agent, CommandAgent, MultiAgentSystem
 
 
 class DummyResponse:
@@ -38,3 +38,24 @@ def test_registry_distribution():
 
     assert agent1.registry == {"agent2": "resp2"}
     assert agent2.registry == {"agent1": "resp1"}
+
+
+def test_agent_reply():
+    agent = Agent(name="tester", responsibility="echo")
+    with patch("llm_call.agents.requests.post", side_effect=fake_post):
+        response = agent.reply("ping")
+    assert response == "echo:ping"
+
+
+def test_send_message():
+    agent = Agent(name="tester", responsibility="echo")
+    system = MultiAgentSystem([agent])
+    with patch("llm_call.agents.requests.post", side_effect=fake_post):
+        reply = system.send_message("tester", "hello")
+    assert reply == "echo:hello"
+
+
+def test_command_agent(tmp_path):
+    agent = CommandAgent(name="runner", responsibility="cmd", root=str(tmp_path))
+    output = agent.reply("echo hi")
+    assert output == "hi"


### PR DESCRIPTION
## Summary
- allow sending a string message to a specific agent
- enable `Agent.reply` for direct responses
- add `CommandAgent` that executes shell commands
- expose `CommandAgent` in package init
- extend unit tests for new behaviours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d16f7314c83279c820bf25c243e01